### PR TITLE
Fix for Editor crash when testing with sockets

### DIFF
--- a/Source/BCClientPlugin/Private/BrainCloudRTTComms.cpp
+++ b/Source/BCClientPlugin/Private/BrainCloudRTTComms.cpp
@@ -392,7 +392,7 @@ void BrainCloudRTTComms::setupWebSocket(const FString &in_url)
 	m_connectedSocket->OnConnectComplete.AddDynamic(m_commsPtr, &UBCRTTCommsProxy::Websocket_OnOpen);
 	m_connectedSocket->OnReceiveData.AddDynamic(m_commsPtr, &UBCRTTCommsProxy::WebSocket_OnMessage);
 
-	m_connectedSocket->SetupSocket(in_url, m_client);
+	m_connectedSocket->SetupSocket(in_url, m_client, m_client->isLoggingEnabled());
 	m_connectedSocket->Connect();
 }
 

--- a/Source/BCClientPlugin/Private/RelayWebSocket.cpp
+++ b/Source/BCClientPlugin/Private/RelayWebSocket.cpp
@@ -16,7 +16,7 @@ namespace BrainCloud
         if (m_connectedSocket == nullptr)
         {
             m_connectedSocket = NewObject<UWinWebSocketBase>();
-            m_connectedSocket->SetupSocket(url, m_client);
+            m_connectedSocket->SetupSocket(url, m_client, m_client->isLoggingEnabled());
 
             m_connectedSocket->mCallbacks = this;
 

--- a/Source/BCClientPlugin/Private/RelayWebSocket.cpp
+++ b/Source/BCClientPlugin/Private/RelayWebSocket.cpp
@@ -105,7 +105,7 @@ namespace BrainCloud
             UE_LOG(LogBrainCloudRelayComms, Log, TEXT("RelayWebSocket OnClosed"));
         }
         
-        close();
+        //close();
     }
 
     void RelayWebSocket::OnConnectComplete()

--- a/Source/BCClientPlugin/Private/RelayWebSocket.cpp
+++ b/Source/BCClientPlugin/Private/RelayWebSocket.cpp
@@ -104,8 +104,6 @@ namespace BrainCloud
         {
             UE_LOG(LogBrainCloudRelayComms, Log, TEXT("RelayWebSocket OnClosed"));
         }
-        
-        //close();
     }
 
     void RelayWebSocket::OnConnectComplete()

--- a/Source/BCClientPlugin/Private/WinWebSocketBase.cpp
+++ b/Source/BCClientPlugin/Private/WinWebSocketBase.cpp
@@ -8,14 +8,16 @@ UWinWebSocketBase::UWinWebSocketBase()
 	FModuleManager::Get().LoadModuleChecked(TEXT("WebSockets"));
 }
 
-void UWinWebSocketBase::SetupSocket(const FString& url, BrainCloudClient* in_client)
+void UWinWebSocketBase::SetupSocket(const FString& url, BrainCloudClient* in_client, bool debugLoggingEnabled)
 {
+	mIsLoggingEnabled = debugLoggingEnabled;
+
 	if(mClient == nullptr && in_client != nullptr)
 	{
 		mClient = in_client;
 	}
 	if (url.IsEmpty()) {
-		if(mClient->isLoggingEnabled())
+		if(mIsLoggingEnabled)
 		{
 			UE_LOG(WinWebSocket, Warning, TEXT("[WinWebSocket] URL is empty"));
 		}
@@ -44,7 +46,7 @@ void UWinWebSocketBase::SetupSocket(const FString& url, BrainCloudClient* in_cli
 
 		WebSocket->OnConnected().AddLambda([this]()
 			{
-				if(mClient->isLoggingEnabled())
+				if(mIsLoggingEnabled)
 				{
 					UE_LOG(WinWebSocket, Log, TEXT("[WinWebSocket] Connected"));
 				}
@@ -54,7 +56,7 @@ void UWinWebSocketBase::SetupSocket(const FString& url, BrainCloudClient* in_cli
 
 		WebSocket->OnClosed().AddLambda([this](uint32 StatusCode, const FString& Reason, bool bWasClean)
 			{
-				if(mClient->isLoggingEnabled())
+				if(mIsLoggingEnabled)
 				{
 					UE_LOG(WinWebSocket, Log, TEXT("[WinWebSocket] Closed - StatusCode: %d Reason: %s WasClean: %s"), StatusCode, *Reason, bWasClean ? TEXT("true") : TEXT("false"));
 				}
@@ -64,7 +66,7 @@ void UWinWebSocketBase::SetupSocket(const FString& url, BrainCloudClient* in_cli
 
 		WebSocket->OnConnectionError().AddLambda([this](const FString& reason)
 			{
-				if(mClient->isLoggingEnabled())
+				if(mIsLoggingEnabled)
 				{
 					UE_LOG(WinWebSocket, Warning, TEXT("[WinWebSocket] Connection error: %s"), *reason);
 				}
@@ -74,7 +76,7 @@ void UWinWebSocketBase::SetupSocket(const FString& url, BrainCloudClient* in_cli
 
 	}
 	else {
-		if(mClient->isLoggingEnabled())
+		if(mIsLoggingEnabled)
 		{
 			UE_LOG(WinWebSocket, Warning, TEXT("[WinWebSocket] Couldn't setup"));
 		}
@@ -89,7 +91,7 @@ void UWinWebSocketBase::Connect()
 	if (WebSocket.IsValid() && !WebSocket->IsConnected())
 	{
 		WebSocket->Connect();
-		if(mClient->isLoggingEnabled())
+		if(mIsLoggingEnabled)
 		{
 			UE_LOG(LogTemp, Log, TEXT("[WebSocket] Connecting..."));
 		}

--- a/Source/BCClientPlugin/Private/WinWebSocketBase.h
+++ b/Source/BCClientPlugin/Private/WinWebSocketBase.h
@@ -32,7 +32,7 @@ class BCCLIENTPLUGIN_API UWinWebSocketBase : public UObject
 public:
 	UWinWebSocketBase();
 
-	void SetupSocket(const FString& url, BrainCloudClient* in_client);
+	void SetupSocket(const FString& url, BrainCloudClient* in_client, bool debugLoggingEnabled);
 
 	void Connect();
 
@@ -63,6 +63,7 @@ private:
 	FString ServerUrl;
 	TArray<FString> mSendQueue;
 	TArray<TArray<uint8>> mSendQueueData;
+	bool mIsLoggingEnabled;
 	
 };
 


### PR DESCRIPTION
This is a fix for the crash issue that happens when we are testing socket connections in the editor. It is when the crash log would point to the isLoggingEnabled() function of the BrainCloudClient class.

