### PR TITLE
Release/5.2

### DIFF
--- a/Source/BCClientPlugin/Public/BrainCloudACL.h
+++ b/Source/BCClientPlugin/Public/BrainCloudACL.h
@@ -1,6 +1,7 @@
 // Copyright 2018 bitHeads, Inc. All Rights Reserved.
 #pragma once
 
+#include "Dom/JsonObject.h"
 #include "IAcl.h"
 #include "BrainCloudACL.generated.h"
 


### PR DESCRIPTION

Eliminates build error when PCH usage is shared (legacy build setting).