### PR TITLE
Implemented CanReconnect function

### DIFF
--- a/Source/BCClientPlugin/Private/BlueprintProxies/BCPlayerStateProxy.h
+++ b/Source/BCClientPlugin/Private/BlueprintProxies/BCPlayerStateProxy.h
@@ -59,7 +59,7 @@ class UBCPlayerStateProxy : public UBCBlueprintCallProxyBase
     * 
     * (Note: Recommend using the Wrapper logout function instead)
     */
-    UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = "true"), Category = "BrainCloud|Player State")
+    UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = "true", DeprecatedFunction, DeprecationMessage="This function has been deprecated, please use the logout function from the Wrapper instead"), Category = "BrainCloud|Player State")
     static UBCPlayerStateProxy *Logout(UBrainCloudWrapper *brainCloudWrapper);
 
     /**

--- a/Source/BCClientPlugin/Private/BlueprintProxies/BCWrapperProxy.cpp
+++ b/Source/BCClientPlugin/Private/BlueprintProxies/BCWrapperProxy.cpp
@@ -380,6 +380,11 @@ UBCWrapperProxy *UBCWrapperProxy::reconnect(UBrainCloudWrapper *brainCloudWrappe
     return Proxy;
 }
 
+bool UBCWrapperProxy::CanReconnect(UBrainCloudWrapper* brainCloudWrapper)
+{
+	return UBCWrapperProxy::GetBrainCloudInstance(brainCloudWrapper)->canReconnect();
+}
+
 void UBCWrapperProxy::SetStoredProfileId(UBrainCloudWrapper *brainCloudWrapper, FString profileId)
 {
     UBCWrapperProxy::GetBrainCloudInstance(brainCloudWrapper)->setStoredProfileId(profileId);

--- a/Source/BCClientPlugin/Private/BlueprintProxies/BCWrapperProxy.h
+++ b/Source/BCClientPlugin/Private/BlueprintProxies/BCWrapperProxy.h
@@ -805,7 +805,13 @@ public:
        */
     UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = "true"), Category = "BrainCloud|Wrapper")
     static UBCWrapperProxy* reconnect(UBrainCloudWrapper *brainCloudWrapper);
- 
+
+    /**
+       * returns true if we can relogin a user
+       */
+    UFUNCTION(BlueprintCallable, Category = "BrainCloud|Wrapper")
+    static bool CanReconnect(UBrainCloudWrapper* brainCloudWrapper);
+
     /**
        * Sets the stored profile id, saves it as well
        * @param profileId The profile id to set
@@ -824,8 +830,8 @@ public:
      * Returns the stored anonymous id
      * @return The stored anonymous id
      */
-  UFUNCTION(BlueprintCallable, Category = "BrainCloud|Wrapper")
-  static FString GetStoredProfileId(UBrainCloudWrapper *brainCloudWrapper);
+    UFUNCTION(BlueprintCallable, Category = "BrainCloud|Wrapper")
+    static FString GetStoredProfileId(UBrainCloudWrapper *brainCloudWrapper);
 
   /**
      * Sets the stored anonymous id, saves it as well

--- a/Source/BCClientPlugin/Private/BrainCloudAuthentication.cpp
+++ b/Source/BCClientPlugin/Private/BrainCloudAuthentication.cpp
@@ -284,7 +284,7 @@ void BrainCloudAuthentication::authenticate(
 	message->SetStringField(OperationParam::AuthenticateServiceAuthenticateReleasePlatform.getValue(), brainCloudClientRef->getReleasePlatform());
 	message->SetStringField(OperationParam::AuthenticateServiceAuthenticateGameVersion.getValue(), brainCloudClientRef->getAppVersion());
 	message->SetStringField(OperationParam::AuthenticateServiceAuthenticateBrainCloudVersion.getValue(), brainCloudClientRef->getBrainCloudClientVersion());
-	message->SetStringField(TEXT("clientLib"), TEXT("UnrealEngine"));
+	message->SetStringField(TEXT("clientLib"), TEXT("Unreal"));
 
 	if (OperationParam::isOptionalParamValid(externalAuthName))
 	{

--- a/Source/BCClientPlugin/Private/BrainCloudAuthentication.cpp
+++ b/Source/BCClientPlugin/Private/BrainCloudAuthentication.cpp
@@ -284,7 +284,7 @@ void BrainCloudAuthentication::authenticate(
 	message->SetStringField(OperationParam::AuthenticateServiceAuthenticateReleasePlatform.getValue(), brainCloudClientRef->getReleasePlatform());
 	message->SetStringField(OperationParam::AuthenticateServiceAuthenticateGameVersion.getValue(), brainCloudClientRef->getAppVersion());
 	message->SetStringField(OperationParam::AuthenticateServiceAuthenticateBrainCloudVersion.getValue(), brainCloudClientRef->getBrainCloudClientVersion());
-	message->SetStringField(TEXT("clientLib"), TEXT("ue4"));
+	message->SetStringField(TEXT("clientLib"), TEXT("UnrealEngine"));
 
 	if (OperationParam::isOptionalParamValid(externalAuthName))
 	{

--- a/Source/BCClientPlugin/Private/BrainCloudComms.cpp
+++ b/Source/BCClientPlugin/Private/BrainCloudComms.cpp
@@ -889,8 +889,11 @@ void BrainCloudComms::FilterIncomingMessages(TSharedRef<ServerCall> servercall, 
 		_isAuthenticated = false;
 		_sessionId = TEXT("");
 		ResetErrorCache();
-		_client->getAuthenticationService()->clearSavedProfileId();
 		_client->getPlayerStateService()->setUserName(TEXT(""));
+
+		if (operation == ServiceOperation::FullReset) {
+			_client->getAuthenticationService()->clearSavedProfileId();
+		}
 	}
 	else if (service == ServiceName::PlayerState && operation == ServiceOperation::UpdateName)
 	{

--- a/Source/BCClientPlugin/Public/BrainCloudWrapper.h
+++ b/Source/BCClientPlugin/Public/BrainCloudWrapper.h
@@ -873,6 +873,8 @@ class BCCLIENTPLUGIN_API UBrainCloudWrapper : public UObject, public IServerCall
      */
     BrainCloudClient *getBCClient() { return _client; }
 
+    bool canReconnect() { return getStoredProfileId() != "" && getStoredAnonymousId() != ""; }
+
     /**
      * Returns the stored profile id
      * @return The stored profile id


### PR DESCRIPTION
- Implemented CanReconnect function
- Removed default behavior of clearing profileID on logout response
- Deprecated old blueprint Logout function from PlayerState 
- Updated clientLib value sent to brainCloud on login success