### PR TITLE
Nick/compression

### DIFF
--- a/Source/BCClientPlugin/Private/BlueprintProxies/BCClientProxy.cpp
+++ b/Source/BCClientPlugin/Private/BlueprintProxies/BCClientProxy.cpp
@@ -12,6 +12,11 @@ UBCClientProxy::UBCClientProxy(const FObjectInitializer &ObjectInitializer)
 {
 }
 
+void UBCClientProxy::EnableCompression(UBrainCloudWrapper* brainCloudWrapper, const bool compress)
+{
+	UBCWrapperProxy::GetBrainCloudInstance(brainCloudWrapper)->getBCClient()->EnableCompression(compress);
+}
+
 void UBCClientProxy::Initialize(
 	UBrainCloudWrapper *brainCloudWrapper,
 	const FString &serverUrl,

--- a/Source/BCClientPlugin/Private/BlueprintProxies/BCClientProxy.cpp
+++ b/Source/BCClientPlugin/Private/BlueprintProxies/BCClientProxy.cpp
@@ -12,9 +12,14 @@ UBCClientProxy::UBCClientProxy(const FObjectInitializer &ObjectInitializer)
 {
 }
 
-void UBCClientProxy::EnableCompression(UBrainCloudWrapper* brainCloudWrapper, const bool compress)
+void UBCClientProxy::EnableCompressedRequests(UBrainCloudWrapper* brainCloudWrapper, const bool isEnabled)
 {
-	UBCWrapperProxy::GetBrainCloudInstance(brainCloudWrapper)->getBCClient()->EnableCompression(compress);
+	UBCWrapperProxy::GetBrainCloudInstance(brainCloudWrapper)->getBCClient()->EnableCompressedRequests(isEnabled);
+}
+
+void UBCClientProxy::EnableCompressedResponses(UBrainCloudWrapper* brainCloudWrapper, const bool isEnabled)
+{
+	UBCWrapperProxy::GetBrainCloudInstance(brainCloudWrapper)->getBCClient()->EnableCompressedResponses(isEnabled);
 }
 
 void UBCClientProxy::Initialize(

--- a/Source/BCClientPlugin/Private/BlueprintProxies/BCClientProxy.h
+++ b/Source/BCClientPlugin/Private/BlueprintProxies/BCClientProxy.h
@@ -13,8 +13,22 @@ class UBCClientProxy : public UBCBlueprintCallProxyBase
   public:
 	UBCClientProxy(const FObjectInitializer &ObjectInitializer);
 
+
+	/**
+	* Enables / Disables compression of API requests, disabled by default
+	*
+	* Param - isEnabled Boolean to decide whether to enable or disable compression
+	*/
 	UFUNCTION(BlueprintCallable, Category = "BrainCloud|Client")
-	static void EnableCompression(UBrainCloudWrapper* brainCloudWrapper, const bool compress);
+	static void EnableCompressedRequests(UBrainCloudWrapper* brainCloudWrapper, const bool isEnabled);
+
+	/**
+	* Enables / Disables compression of API responses, disabled by default
+	*
+	* Param - isEnabled Boolean to decide whether to enable or disable compression
+	*/
+	UFUNCTION(BlueprintCallable, Category = "BrainCloud|Client")
+	static void EnableCompressedResponses(UBrainCloudWrapper* brainCloudWrapper, const bool isEnabled);
 
 	/**
 	* Method initializes the BrainCloudClient.

--- a/Source/BCClientPlugin/Private/BlueprintProxies/BCClientProxy.h
+++ b/Source/BCClientPlugin/Private/BlueprintProxies/BCClientProxy.h
@@ -13,6 +13,9 @@ class UBCClientProxy : public UBCBlueprintCallProxyBase
   public:
 	UBCClientProxy(const FObjectInitializer &ObjectInitializer);
 
+	UFUNCTION(BlueprintCallable, Category = "BrainCloud|Client")
+	static void EnableCompression(UBrainCloudWrapper* brainCloudWrapper, const bool compress);
+
 	/**
 	* Method initializes the BrainCloudClient.
 	*

--- a/Source/BCClientPlugin/Private/BrainCloudAuthentication.cpp
+++ b/Source/BCClientPlugin/Private/BrainCloudAuthentication.cpp
@@ -33,6 +33,7 @@ void BrainCloudAuthentication::initialize(const FString &profileId, const FStrin
 {
 	_profileId = profileId;
 	_anonymousId = anonymousId;
+	CompressResponses = true;
 }
 
 FString BrainCloudAuthentication::generateAnonymousId()

--- a/Source/BCClientPlugin/Private/BrainCloudAuthentication.cpp
+++ b/Source/BCClientPlugin/Private/BrainCloudAuthentication.cpp
@@ -33,7 +33,6 @@ void BrainCloudAuthentication::initialize(const FString &profileId, const FStrin
 {
 	_profileId = profileId;
 	_anonymousId = anonymousId;
-	CompressResponses = true;
 }
 
 FString BrainCloudAuthentication::generateAnonymousId()

--- a/Source/BCClientPlugin/Private/BrainCloudAuthentication.cpp
+++ b/Source/BCClientPlugin/Private/BrainCloudAuthentication.cpp
@@ -289,7 +289,7 @@ void BrainCloudAuthentication::authenticate(
 	message->SetStringField(OperationParam::AuthenticateServiceAuthenticateAuthenticationToken.getValue(), authenticationToken);
 	message->SetStringField(OperationParam::AuthenticateServiceAuthenticateAuthenticationType.getValue(), BCAuthType::EnumToString(authenticationType));
 	message->SetBoolField(OperationParam::AuthenticateServiceAuthenticateForceCreate.getValue(), forceCreate);
-// compressResponses?
+	message->SetBoolField(OperationParam::AuthenticateServiceAuthenticateCompressResponses.getValue(), CompressResponses);
     
 	message->SetStringField(OperationParam::AuthenticateServiceAuthenticateProfileId.getValue(), _profileId);
 	message->SetStringField(OperationParam::AuthenticateServiceAuthenticateAnonymousId.getValue(), _anonymousId);

--- a/Source/BCClientPlugin/Private/BrainCloudClient.cpp
+++ b/Source/BCClientPlugin/Private/BrainCloudClient.cpp
@@ -90,12 +90,20 @@ BrainCloudClient::~BrainCloudClient()
 	destroyService(_messagingService);
 }
 
+
+
 ////////////////////////////////////////////////////
 // Public Methods
 ////////////////////////////////////////////////////
 
-void BrainCloudClient::EnableCompression(bool compress) {
-	_brainCloudComms->EnableCompression(compress);
+void BrainCloudClient::EnableCompressedRequests(bool isEnabled)
+{
+	_brainCloudComms->EnableCompression(isEnabled);
+}
+
+void BrainCloudClient::EnableCompressedResponses(bool isEnabled)
+{
+	_authenticationService->CompressResponses = isEnabled;
 }
 
 void BrainCloudClient::initialize(

--- a/Source/BCClientPlugin/Private/BrainCloudClient.cpp
+++ b/Source/BCClientPlugin/Private/BrainCloudClient.cpp
@@ -94,6 +94,10 @@ BrainCloudClient::~BrainCloudClient()
 // Public Methods
 ////////////////////////////////////////////////////
 
+void BrainCloudClient::EnableCompression(bool compress) {
+	_brainCloudComms->EnableCompression(compress);
+}
+
 void BrainCloudClient::initialize(
 	const FString &serverUrl,
 	const FString &secretKey,

--- a/Source/BCClientPlugin/Private/BrainCloudComms.cpp
+++ b/Source/BCClientPlugin/Private/BrainCloudComms.cpp
@@ -302,7 +302,7 @@ TSharedRef<IHttpRequest> BrainCloudComms::SendPacket(PacketRef packet)
 		//compress the bytes here
 		httpRequest->SetHeader(TEXT("Content-Encoding"), TEXT("gzip"));
 		httpRequest->SetHeader(TEXT("Accept-Encoding"), TEXT("gzip"));
-		bytes = ConvertUtilities::CompressBytes(bytes);
+		bytes = ConvertUtilities::CompressBytes(bytes, _isLoggingEnabled);
 	}
 
 	httpRequest->SetContent(bytes);

--- a/Source/BCClientPlugin/Private/BrainCloudComms.h
+++ b/Source/BCClientPlugin/Private/BrainCloudComms.h
@@ -191,7 +191,7 @@ class BrainCloudComms
 
 	//compression
 	bool _supportsCompression = true;
-	int32 _clientSideCompressionThreshold = 0;
+	int32 _clientSideCompressionThreshold = 50000;
 
 	//For kill switch
 	int32 _killSwitchThreshold = 11;

--- a/Source/BCClientPlugin/Private/BrainCloudComms.h
+++ b/Source/BCClientPlugin/Private/BrainCloudComms.h
@@ -96,6 +96,10 @@ class BrainCloudComms
 	void RetryCachedMessages();
 	void FlushCachedMessages(bool sendApiErrorCallbacks);
 
+	//Compression
+	void EnableCompression(bool compress);
+	bool IsCompressionEnabled();
+
   private:
 	void CreateAndSendNextRequestBundle();
 	PacketRef BuildPacket();
@@ -184,6 +188,10 @@ class BrainCloudComms
 	//caching
 	bool _cacheMessagesOnNetworkError = false;
 	bool _blockingQueue = false;
+
+	//compression
+	bool _supportsCompression = true;
+	int32 _clientSideCompressionThreshold = 0;
 
 	//For kill switch
 	int32 _killSwitchThreshold = 11;

--- a/Source/BCClientPlugin/Private/BrainCloudComms.h
+++ b/Source/BCClientPlugin/Private/BrainCloudComms.h
@@ -190,7 +190,7 @@ class BrainCloudComms
 	bool _blockingQueue = false;
 
 	//compression
-	bool _supportsCompression = true;
+	bool _supportsCompression = false;
 	int32 _clientSideCompressionThreshold = 50000;
 
 	//For kill switch

--- a/Source/BCClientPlugin/Private/BrainCloudRelayComms.cpp
+++ b/Source/BCClientPlugin/Private/BrainCloudRelayComms.cpp
@@ -536,12 +536,6 @@ void BrainCloudRelayComms::send(int netId, const TSharedRef<FJsonObject>& json)
 
 void BrainCloudRelayComms::send(int netId, const FString& text)
 {
-    if (m_client->isLoggingEnabled())
-    {
-        //UE_LOG(LogBrainCloudRelayComms, Log, TEXT("RELAY SEND: %s"), *text);
-    }
-
-
     uint8 bytes[1024];
     int32 bytesLen = ConvertUtilities::BCStringToBytes(text, bytes, 1024);
 

--- a/Source/BCClientPlugin/Private/ConvertUtilities.cpp
+++ b/Source/BCClientPlugin/Private/ConvertUtilities.cpp
@@ -1,4 +1,7 @@
 #include "ConvertUtilities.h"
+#include "Serialization/MemoryWriter.h"
+#include "Serialization/MemoryReader.h"
+#include <Misc/Compression.h>
 
 FString ConvertUtilities::BCBytesToString(const TArray<uint8>& in)
 {
@@ -19,3 +22,68 @@ int32 ConvertUtilities::BCStringToBytes(const FString &in_string, uint8 *out_byt
 	}
 	return numBytes;
 }
+
+TArray<uint8> ConvertUtilities::BCStringToBytesArray(const FString& in_string)
+{
+	FTCHARToUTF8 Converter(*in_string);
+	const char* Utf8String = Converter.Get();
+	int32 Utf8Length = Converter.Length();
+
+	TArray<uint8> ByteArray;
+	ByteArray.Append(reinterpret_cast<const uint8*>(Utf8String), Utf8Length);
+
+	return ByteArray;
+}
+
+FString ConvertUtilities::BCBytesArrayToString(const TArray<uint8> in_array)
+{
+	return FUTF8ToTCHAR(reinterpret_cast<const ANSICHAR*>(in_array.GetData()), in_array.Num()).Get();
+}
+
+TArray<uint8> ConvertUtilities::CompressBytes(const TArray<uint8>& UncompressedData, FName CompressionFormat)
+{
+	TArray<uint8> CompressedData;
+
+	if (UncompressedData.Num() > 0)
+	{
+		// Estimate the worst-case size for the compressed data
+		int32 CompressedSize = FCompression::CompressMemoryBound(CompressionFormat, UncompressedData.Num());
+		CompressedData.SetNumUninitialized(CompressedSize);
+
+		// Compress the data
+		if (FCompression::CompressMemory(CompressionFormat, CompressedData.GetData(), CompressedSize, UncompressedData.GetData(), UncompressedData.Num()))
+		{
+			// Resize the array to the actual compressed size
+			CompressedData.SetNum(CompressedSize);
+		}
+		else
+		{
+			// Handle compression failure
+			CompressedData.Empty();
+			UE_LOG(LogTemp, Error, TEXT("Failed to compress data."));
+		}
+	}
+
+	return CompressedData;
+}
+
+TArray<uint8> ConvertUtilities::DecompressBytes(const TArray<uint8>& CompressedData, int32 UncompressedSize, FName CompressionFormat)
+{
+	TArray<uint8> DecompressedData;
+	DecompressedData.SetNumUninitialized(UncompressedSize);
+
+	if (CompressedData.Num() > 0)
+	{
+		// Decompress the data
+		if (!FCompression::UncompressMemory(CompressionFormat, DecompressedData.GetData(), UncompressedSize, CompressedData.GetData(), CompressedData.Num()))
+		{
+			// Handle decompression failure
+			DecompressedData.Empty();
+			UE_LOG(LogTemp, Error, TEXT("Failed to decompress data."));
+		}
+	}
+
+	return DecompressedData;
+}
+
+

--- a/Source/BCClientPlugin/Private/ConvertUtilities.cpp
+++ b/Source/BCClientPlugin/Private/ConvertUtilities.cpp
@@ -60,7 +60,7 @@ FString ConvertUtilities::BCBytesArrayToString(const TArray<uint8> in_array)
 	return FUTF8ToTCHAR(reinterpret_cast<const ANSICHAR*>(in_array.GetData()), length).Get();
 }
 
-TArray<uint8> ConvertUtilities::CompressBytes(const TArray<uint8>& UncompressedData)
+TArray<uint8> ConvertUtilities::CompressBytes(const TArray<uint8>& UncompressedData, bool enableLogging)
 {
 	TArray<uint8> CompressedData;
 
@@ -72,7 +72,8 @@ TArray<uint8> ConvertUtilities::CompressBytes(const TArray<uint8>& UncompressedD
 		// Compress the data
 		if (FCompression::CompressMemory(NAME_Gzip, CompressedData.GetData(), CompressedSize, UncompressedData.GetData(), UncompressedData.Num(), COMPRESS_GZIP))
 		{
-			UE_LOG(LogTemp, Log, TEXT("Compress using GZIP successful"));
+			if(enableLogging)
+				UE_LOG(LogTemp, Log, TEXT("Compress using GZIP successful"));
 		}
 		else
 		{

--- a/Source/BCClientPlugin/Private/OperationParam.cpp
+++ b/Source/BCClientPlugin/Private/OperationParam.cpp
@@ -71,6 +71,7 @@ const OperationParam OperationParam::AuthenticateServiceAuthenticateAuthExternal
 const OperationParam OperationParam::AuthenticateServiceAuthenticateAnonymousId = OperationParam("anonymousId");
 const OperationParam OperationParam::AuthenticateServiceAuthenticateProfileId = OperationParam("profileId");
 const OperationParam OperationParam::AuthenticateServiceAuthenticateForceCreate = OperationParam("forceCreate");
+const OperationParam OperationParam::AuthenticateServiceAuthenticateCompressResponses = OperationParam("compressResponses");
 const OperationParam OperationParam::AuthenticateServiceAuthenticateExternalAuthName = OperationParam("externalAuthName");
 const OperationParam OperationParam::AuthenticateServiceAuthenticateRegion = OperationParam("region");
 const OperationParam OperationParam::AuthenticateServiceAuthenticateCountryCode = OperationParam("countryCode");

--- a/Source/BCClientPlugin/Public/BrainCloudAuthentication.h
+++ b/Source/BCClientPlugin/Public/BrainCloudAuthentication.h
@@ -503,6 +503,8 @@ public:
   void setAnonymousId(const FString &anonymousId);
   void setProfileId(const FString &profileId);
 
+  bool CompressResponses = true;
+
 private:
   BrainCloudClient *_client = nullptr;
 

--- a/Source/BCClientPlugin/Public/BrainCloudAuthentication.h
+++ b/Source/BCClientPlugin/Public/BrainCloudAuthentication.h
@@ -503,7 +503,7 @@ public:
   void setAnonymousId(const FString &anonymousId);
   void setProfileId(const FString &profileId);
 
-  bool CompressResponses = true;
+  bool CompressResponses = false;
 
 private:
   BrainCloudClient *_client = nullptr;

--- a/Source/BCClientPlugin/Public/BrainCloudClient.h
+++ b/Source/BCClientPlugin/Public/BrainCloudClient.h
@@ -127,6 +127,13 @@ class BCCLIENTPLUGIN_API BrainCloudClient
 	~BrainCloudClient();
 
 	/**
+	* Enables / Disables compression of API requests, disabled by default
+	*
+	* @param compress Boolean to decide whether to enable or disable compression
+	*/
+	void EnableCompression(bool compress);
+
+	/**
 	* Method initializes the BrainCloudClient.
 	*
 	* @param serverURL The url to the brainCloud server

--- a/Source/BCClientPlugin/Public/BrainCloudClient.h
+++ b/Source/BCClientPlugin/Public/BrainCloudClient.h
@@ -129,9 +129,16 @@ class BCCLIENTPLUGIN_API BrainCloudClient
 	/**
 	* Enables / Disables compression of API requests, disabled by default
 	*
-	* @param compress Boolean to decide whether to enable or disable compression
+	* @param isEnabled Boolean to decide whether to enable or disable compression
 	*/
-	void EnableCompression(bool compress);
+	void EnableCompressedRequests(bool isEnabled);
+
+	/**
+	* Enables / Disables compression of API responses, disabled by default
+	*
+	* @param isEnabled Boolean to decide whether to enable or disable compression
+	*/
+	void EnableCompressedResponses(bool isEnabled);
 
 	/**
 	* Method initializes the BrainCloudClient.

--- a/Source/BCClientPlugin/Public/ConvertUtilities.h
+++ b/Source/BCClientPlugin/Public/ConvertUtilities.h
@@ -7,6 +7,6 @@ public:
     static int32 BCStringToBytes(const FString &in_string, uint8 *out_bytes, int32 in_maxBufferSize);
     static TArray<uint8> BCStringToBytesArray(const FString& in_string);
     static FString BCBytesArrayToString(const TArray<uint8> in_array);
-    static TArray<uint8> CompressBytes(const TArray<uint8>& UncompressedData);
+    static TArray<uint8> CompressBytes(const TArray<uint8>& UncompressedData, bool enableLogging = false);
     static FString MinifyJson(const FString& JsonString);
 };

--- a/Source/BCClientPlugin/Public/ConvertUtilities.h
+++ b/Source/BCClientPlugin/Public/ConvertUtilities.h
@@ -7,6 +7,6 @@ public:
     static int32 BCStringToBytes(const FString &in_string, uint8 *out_bytes, int32 in_maxBufferSize);
     static TArray<uint8> BCStringToBytesArray(const FString& in_string);
     static FString BCBytesArrayToString(const TArray<uint8> in_array);
-    static TArray<uint8> CompressBytes(const TArray<uint8>& UncompressedData, FName CompressionFormat = NAME_Gzip);
-    static TArray<uint8> DecompressBytes(const TArray<uint8>& CompressedData, int32 UncompressedSize, FName CompressionFormat = NAME_Gzip);
+    static TArray<uint8> CompressBytes(const TArray<uint8>& UncompressedData);
+    static FString MinifyJson(const FString& JsonString);
 };

--- a/Source/BCClientPlugin/Public/ConvertUtilities.h
+++ b/Source/BCClientPlugin/Public/ConvertUtilities.h
@@ -5,4 +5,8 @@ class BCCLIENTPLUGIN_API ConvertUtilities
 public:
     static FString BCBytesToString(const TArray<uint8>& in);
     static int32 BCStringToBytes(const FString &in_string, uint8 *out_bytes, int32 in_maxBufferSize);
+    static TArray<uint8> BCStringToBytesArray(const FString& in_string);
+    static FString BCBytesArrayToString(const TArray<uint8> in_array);
+    static TArray<uint8> CompressBytes(const TArray<uint8>& UncompressedData, FName CompressionFormat = NAME_Gzip);
+    static TArray<uint8> DecompressBytes(const TArray<uint8>& CompressedData, int32 UncompressedSize, FName CompressionFormat = NAME_Gzip);
 };

--- a/Source/BCClientPlugin/Public/OperationParam.h
+++ b/Source/BCClientPlugin/Public/OperationParam.h
@@ -71,6 +71,7 @@ class BCCLIENTPLUGIN_API OperationParam
 	static const OperationParam AuthenticateServiceAuthenticateAnonymousId;
 	static const OperationParam AuthenticateServiceAuthenticateProfileId;
 	static const OperationParam AuthenticateServiceAuthenticateForceCreate;
+	static const OperationParam AuthenticateServiceAuthenticateCompressResponses;
 	static const OperationParam AuthenticateServiceAuthenticateExternalAuthName;
 	static const OperationParam AuthenticateServiceAuthenticateRegion;
 	static const OperationParam AuthenticateServiceAuthenticateCountryCode;


### PR DESCRIPTION
Implemented compression in Unreal library 

It is disabled by default for the moment but can be enabled using new functions in the client:

- **EnableCompressedRequests(bool isEnabled)**
- **EnableCompressedResponses(bool isEnabled)**

These functions can also be used in Blueprints

Also fixed a client side issue where GetServerVersion wasn't working if the user wasn't authenticated

Green test: https://vmjenkins.bitheads.com/view/Dev_Unreal/job/bitHeads_BrainCloud_Client_UnitTest_UnrealEngine_MacOS_develop_internal/994/console