### PR TITLE
Nick/warnings fix

### DIFF
--- a/Source/BCClientPlugin/Private/BrainCloudComms.cpp
+++ b/Source/BCClientPlugin/Private/BrainCloudComms.cpp
@@ -894,8 +894,8 @@ void BrainCloudComms::FilterIncomingMessages(TSharedRef<ServerCall> servercall, 
 
 		if (isDataValid)
 		{
-			if ((*data)->HasField("compressIfLarger")) {
-				_clientSideCompressionThreshold = (*data)->GetIntegerField("compressIfLarger");
+			if ((*data)->HasField(TEXT("compressIfLarger"))) {
+				_clientSideCompressionThreshold = (*data)->GetIntegerField(TEXT("compressIfLarger"));
 			}
 
 			if (_heartbeatInterval == 0)

--- a/Source/BCClientPlugin/Private/BrainCloudRelayComms.cpp
+++ b/Source/BCClientPlugin/Private/BrainCloudRelayComms.cpp
@@ -444,7 +444,11 @@ void BrainCloudRelayComms::send(const TArray<uint8> &in_dataArr, uint64 in_playe
     // Allocate buffer
     auto totalSize = in_size + 11;
     auto pPacket = m_packetPool.alloc();
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 5
+    pPacket->data.SetNum(totalSize,EAllowShrinking::No);
+#else
     pPacket->data.SetNum(totalSize, false);
+#endif
 
     // Size
     auto len = hostToNet((uint16)totalSize);

--- a/Source/BCClientPlugin/Private/RelayUDPSocket.cpp
+++ b/Source/BCClientPlugin/Private/RelayUDPSocket.cpp
@@ -122,7 +122,11 @@ void BrainCloud::RelayUDPSocket::send(const uint8* pData, int size)
 	int32 BytesSent = 0;
 
 	TArray<uint8> data;
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 5
+	data.SetNum(size, EAllowShrinking::No);
+#else
 	data.SetNum(size, false);
+#endif
 	memcpy(data.GetData(), pData, size);
 	m_connectedSocket->SendTo(data.GetData(), size, BytesSent, *m_remoteAddr);
 

--- a/Source/BCClientPlugin/Private/RelayUDPSocket.cpp
+++ b/Source/BCClientPlugin/Private/RelayUDPSocket.cpp
@@ -10,6 +10,7 @@
 #include <netinet/in.h>
 #endif
 
+#include "Runtime/Launch/Resources/Version.h"
 #include "SocketSubsystem.h"
 #include <Interfaces/IPv4/IPv4Address.h>
 #include <Common/UdpSocketBuilder.h>


### PR DESCRIPTION
Fixed compile warnings for Unreal 5.5 (completing ticket 6820)

Green unit tests:

Linux: https://vmjenkins.bitheads.com/view/Dev_Unreal/job/bitHeads_BrainCloud_Client_UnitTest_UnrealEngine_Linux_develop_internal/36/
MacOS: https://vmjenkins.bitheads.com/view/Dev_Unreal/job/bitHeads_BrainCloud_Client_UnitTest_UnrealEngine_MacOS_develop_internal/1083/
Windows: https://vmjenkins.bitheads.com/view/Dev_Unreal/job/bitHeads_BrainCloud_Client_UnitTest_UnrealEngine_Win64_develop_internal/1164/

Also tested locally on Unreal versions 4.27, 5.3, 5.4 and 5.5