### PR TITLE
Nick/null crash fix

### DIFF
--- a/Source/BCClientPlugin/Private/BlueprintProxies/BCWrapperProxy.cpp
+++ b/Source/BCClientPlugin/Private/BlueprintProxies/BCWrapperProxy.cpp
@@ -6,7 +6,7 @@
 
 #include "BrainCloudWrapper.h"
 
-UBrainCloudWrapper *UBCWrapperProxy::DefaultBrainCloudInstance = nullptr;
+TWeakObjectPtr<UBrainCloudWrapper> UBCWrapperProxy::DefaultBrainCloudInstance = nullptr;
 
 UBCWrapperProxy::UBCWrapperProxy(const FObjectInitializer &ObjectInitializer)
 	: Super(ObjectInitializer)
@@ -15,7 +15,7 @@ UBCWrapperProxy::UBCWrapperProxy(const FObjectInitializer &ObjectInitializer)
 
 UBrainCloudWrapper *UBCWrapperProxy::CreateBrainCloudWrapper(const FString &wrapperName)
 {
-	UBrainCloudWrapper *wrapper = NewObject<UBrainCloudWrapper>();
+	UBrainCloudWrapper* wrapper = NewObject<UBrainCloudWrapper>();
 	wrapper->setWrapperName(wrapperName);
 	return wrapper;
 }
@@ -30,7 +30,7 @@ void UBCWrapperProxy::SetDefaultBrainCloudInstance(UBrainCloudWrapper *brainClou
 
 void UBCWrapperProxy::ClearDefaultBrainCloudInstance()
 {
-	if (DefaultBrainCloudInstance != nullptr)
+	if (ensureAlways(DefaultBrainCloudInstance != nullptr))
 		DefaultBrainCloudInstance->RemoveFromRoot();
 	DefaultBrainCloudInstance = nullptr;
 }
@@ -45,7 +45,7 @@ UBrainCloudWrapper *UBCWrapperProxy::GetBrainCloudInstance(UBrainCloudWrapper *b
 	// Using a default state instance of brainCloud
 	else if (DefaultBrainCloudInstance != nullptr)
 	{
-		return DefaultBrainCloudInstance;
+		return DefaultBrainCloudInstance.Get();
 	}
 	// nullptr! wrapper isn't set!
 	else

--- a/Source/BCClientPlugin/Private/BlueprintProxies/BCWrapperProxy.h
+++ b/Source/BCClientPlugin/Private/BlueprintProxies/BCWrapperProxy.h
@@ -18,7 +18,7 @@ class UBCWrapperProxy : public UBCBlueprintCallProxyBase
   GENERATED_BODY()
 
 public:
-  static UBrainCloudWrapper *DefaultBrainCloudInstance;
+  static TWeakObjectPtr<UBrainCloudWrapper> DefaultBrainCloudInstance;
   UBCWrapperProxy(const FObjectInitializer &ObjectInitializer);
 
   /**

--- a/Source/BCClientPlugin/Private/BrainCloudClient.cpp
+++ b/Source/BCClientPlugin/Private/BrainCloudClient.cpp
@@ -324,7 +324,7 @@ void BrainCloudClient::enableLogging(bool shouldEnable)
 
 bool BrainCloudClient::isLoggingEnabled()
 {
-	return _brainCloudComms->IsLoggingEnabled();
+	return _brainCloudComms != nullptr ? _brainCloudComms->IsLoggingEnabled() : false;
 }
 
 bool BrainCloudClient::isAuthenticated()

--- a/Source/BCClientPlugin/Private/BrainCloudRTTComms.cpp
+++ b/Source/BCClientPlugin/Private/BrainCloudRTTComms.cpp
@@ -211,10 +211,11 @@ void BrainCloudRTTComms::disconnect()
 		m_commsPtr->RemoveFromRoot();
 		m_connectedSocket->Close();
 		m_connectedSocket->RemoveFromRoot();
-		m_connectedSocket->OnConnectError.RemoveDynamic(m_commsPtr, &UBCRTTCommsProxy::WebSocket_OnError);
-		m_connectedSocket->OnClosed.RemoveDynamic(m_commsPtr, &UBCRTTCommsProxy::WebSocket_OnClose);
-		m_connectedSocket->OnConnectComplete.RemoveDynamic(m_commsPtr, &UBCRTTCommsProxy::Websocket_OnOpen);
-		m_connectedSocket->OnReceiveData.RemoveDynamic(m_commsPtr, &UBCRTTCommsProxy::WebSocket_OnMessage);
+		//m_connectedSocket->OnConnectError.RemoveDynamic(m_commsPtr, &UBCRTTCommsProxy::WebSocket_OnError);
+		//m_connectedSocket->OnClosed.RemoveDynamic(m_commsPtr, &UBCRTTCommsProxy::WebSocket_OnClose);
+		//m_connectedSocket->OnConnectComplete.RemoveDynamic(m_commsPtr, &UBCRTTCommsProxy::Websocket_OnOpen);
+		//m_connectedSocket->OnReceiveData.RemoveDynamic(m_commsPtr, &UBCRTTCommsProxy::WebSocket_OnMessage);
+		m_connectedSocket->ResetCallbacks();
 	}
 
 	if (m_commsPtr)
@@ -438,10 +439,18 @@ void BrainCloudRTTComms::webSocket_OnError(const FString &in_message)
 	processRegisteredListeners(ServiceName::RTTRegistration.getValue().ToLower(), "disconnect", UBrainCloudWrapper::buildErrorJson(403, ReasonCodes::RS_CLIENT_ERROR, in_message));
 }
 
-void BrainCloudRTTComms::onRecv(const FString &in_message)
+void BrainCloudRTTComms::onRecv(FString in_message)
 {
 	// deserialize and push broadcast to the correct m_registeredRTTCallbacks
 	TSharedPtr<FJsonObject> jsonData = JsonUtil::jsonStringToValue(in_message);
+
+	if (!jsonData.IsValid())
+	{
+		if (isLoggingEnabled())
+			UE_LOG(LogBrainCloudComms, Log, TEXT("Failed to parse incoming JSON message: %s"), *in_message);
+		return;
+	}
+
 	FString service = jsonData->HasField(TEXT("service")) ? jsonData->GetStringField(TEXT("service")) : "";
 	FString operation = jsonData->HasField(TEXT("operation")) ? jsonData->GetStringField(TEXT("operation")) : "";
 	TSharedPtr<FJsonObject> innerData = nullptr;

--- a/Source/BCClientPlugin/Private/BrainCloudRTTComms.cpp
+++ b/Source/BCClientPlugin/Private/BrainCloudRTTComms.cpp
@@ -472,9 +472,11 @@ void BrainCloudRTTComms::onRecv(const FString &in_message)
 	else if (operation == "DISCONNECT")
 	{
 		m_disconnectedWithReason = true;
-		m_disconnectJson->SetStringField("reason", innerData->GetStringField(TEXT("reason")));
-		m_disconnectJson->SetNumberField("reasonCode", innerData->GetNumberField(TEXT("reasonCode")));
-		m_disconnectJson->SetStringField("severity", "ERROR");
+		if (ensureAlways(innerData != nullptr)) {
+			m_disconnectJson->SetStringField("reason", innerData->GetStringField(TEXT("reason")));
+			m_disconnectJson->SetNumberField("reasonCode", innerData->GetNumberField(TEXT("reasonCode")));
+			m_disconnectJson->SetStringField("severity", "ERROR");
+		}
 	}
 
 	if (bIsInnerDataValid)

--- a/Source/BCClientPlugin/Private/BrainCloudRTTComms.cpp
+++ b/Source/BCClientPlugin/Private/BrainCloudRTTComms.cpp
@@ -209,13 +209,9 @@ void BrainCloudRTTComms::disconnect()
 	if (m_connectedSocket != nullptr && m_commsPtr != nullptr)
 	{
 		m_commsPtr->RemoveFromRoot();
+		m_connectedSocket->ResetCallbacks();
 		m_connectedSocket->Close();
 		m_connectedSocket->RemoveFromRoot();
-		//m_connectedSocket->OnConnectError.RemoveDynamic(m_commsPtr, &UBCRTTCommsProxy::WebSocket_OnError);
-		//m_connectedSocket->OnClosed.RemoveDynamic(m_commsPtr, &UBCRTTCommsProxy::WebSocket_OnClose);
-		//m_connectedSocket->OnConnectComplete.RemoveDynamic(m_commsPtr, &UBCRTTCommsProxy::Websocket_OnOpen);
-		//m_connectedSocket->OnReceiveData.RemoveDynamic(m_commsPtr, &UBCRTTCommsProxy::WebSocket_OnMessage);
-		m_connectedSocket->ResetCallbacks();
 	}
 
 	if (m_commsPtr)

--- a/Source/BCClientPlugin/Private/BrainCloudRTTComms.h
+++ b/Source/BCClientPlugin/Private/BrainCloudRTTComms.h
@@ -100,7 +100,7 @@ class BrainCloudRTTComms : public IServerCallback
 
 	// private vars
 	BrainCloudClient *m_client = nullptr;
-	TWeakObjectPtr<IServerCallback> m_appCallback;
+	IServerCallback *m_appCallback;
 	UBCRTTProxy *m_appCallbackBP;
 
 	TMap<FString, IRTTCallback *> m_registeredRTTCallbacks;

--- a/Source/BCClientPlugin/Private/BrainCloudRTTComms.h
+++ b/Source/BCClientPlugin/Private/BrainCloudRTTComms.h
@@ -88,7 +88,7 @@ class BrainCloudRTTComms : public IServerCallback
 	void setupWebSocket(const FString &in_url);
 
 	void setEndpointFromType(TArray<TSharedPtr<FJsonValue>> in_endpoints, FString in_socketType);
-	void onRecv(const FString &in_message);
+	void onRecv(FString in_message);
 
 	FString buildRTTRequestError(FString in_statusMessage);
 	
@@ -100,7 +100,7 @@ class BrainCloudRTTComms : public IServerCallback
 
 	// private vars
 	BrainCloudClient *m_client = nullptr;
-	IServerCallback *m_appCallback;
+	TWeakObjectPtr<IServerCallback> m_appCallback;
 	UBCRTTProxy *m_appCallbackBP;
 
 	TMap<FString, IRTTCallback *> m_registeredRTTCallbacks;

--- a/Source/BCClientPlugin/Private/WinWebSocketBase.cpp
+++ b/Source/BCClientPlugin/Private/WinWebSocketBase.cpp
@@ -164,7 +164,7 @@ bool UWinWebSocketBase::IsConnected()
 
 bool UWinWebSocketBase::IsLoggingEnabled()
 {
-	if (mClient != nullptr) {
+	if (ensureAlways(mClient != nullptr)) {
 		return mClient->isLoggingEnabled();
 	}
 

--- a/Source/BCClientPlugin/Private/WinWebSocketBase.cpp
+++ b/Source/BCClientPlugin/Private/WinWebSocketBase.cpp
@@ -31,7 +31,7 @@ void UWinWebSocketBase::SetupSocket(const FString& url, BrainCloudClient* client
 	
 
 	if (url.IsEmpty()) {
-		if(mIsLoggingEnabled)
+		if(IsLoggingEnabled())
 		{
 			UE_LOG(WinWebSocket, Warning, TEXT("[WinWebSocket] URL is empty"));
 		}
@@ -43,6 +43,7 @@ void UWinWebSocketBase::SetupSocket(const FString& url, BrainCloudClient* client
 	WebSocket = FWebSocketsModule::Get().CreateWebSocket(url);
 
 	if (WebSocket.IsValid()) {
+
 		TWeakObjectPtr<UWinWebSocketBase> WeakThis = this;
 
 		WebSocket->OnMessage().AddLambda([WeakThis](const FString& data)
@@ -107,7 +108,7 @@ void UWinWebSocketBase::Connect()
 	if (WebSocket.IsValid() && !WebSocket->IsConnected())
 	{
 		WebSocket->Connect();
-		if(mIsLoggingEnabled)
+		if(IsLoggingEnabled())
 		{
 			UE_LOG(LogTemp, Log, TEXT("[WebSocket] Connecting..."));
 		}

--- a/Source/BCClientPlugin/Private/WinWebSocketBase.cpp
+++ b/Source/BCClientPlugin/Private/WinWebSocketBase.cpp
@@ -25,11 +25,9 @@ UWinWebSocketBase::UWinWebSocketBase()
 
 void UWinWebSocketBase::SetupSocket(const FString& url, BrainCloudClient* in_client)
 {
-
-	mClient = in_client;
+	mClient = ensureAlways(in_client != nullptr) ? in_client : mClient;
 	mIsLoggingEnabled = mClient->isLoggingEnabled();
 	
-
 	if (url.IsEmpty()) {
 		if(IsLoggingEnabled())
 		{
@@ -152,7 +150,6 @@ void UWinWebSocketBase::ResetCallbacks()
 	OnReceiveMessage.Clear();
 	OnReceiveData.Clear();
 	OnConnectComplete.Clear();
-	OnConnectError.Clear();
 	OnConnectError.Clear();
 
 }

--- a/Source/BCClientPlugin/Private/WinWebSocketBase.cpp
+++ b/Source/BCClientPlugin/Private/WinWebSocketBase.cpp
@@ -23,10 +23,10 @@ UWinWebSocketBase::UWinWebSocketBase()
 	FModuleManager::Get().LoadModuleChecked(TEXT("WebSockets"));
 }
 
-void UWinWebSocketBase::SetupSocket(const FString& url, BrainCloudClient* client)
+void UWinWebSocketBase::SetupSocket(const FString& url, BrainCloudClient* in_client)
 {
 
-	mClient = client;
+	mClient = in_client;
 	mIsLoggingEnabled = mClient->isLoggingEnabled();
 	
 

--- a/Source/BCClientPlugin/Private/WinWebSocketBase.h
+++ b/Source/BCClientPlugin/Private/WinWebSocketBase.h
@@ -36,7 +36,7 @@ protected:
 public:
 	UWinWebSocketBase();
 
-	void SetupSocket(const FString& url, BrainCloudClient* mClient);
+	void SetupSocket(const FString& url, BrainCloudClient* in_client);
 
 	void Connect();
 

--- a/Source/BCClientPlugin/Private/WinWebSocketBase.h
+++ b/Source/BCClientPlugin/Private/WinWebSocketBase.h
@@ -29,10 +29,14 @@ UCLASS(Blueprintable, BlueprintType)
 class BCCLIENTPLUGIN_API UWinWebSocketBase : public UObject
 {
 	GENERATED_BODY()
+
+protected:
+	void BeginDestroy() override;
+
 public:
 	UWinWebSocketBase();
 
-	void SetupSocket(const FString& url, BrainCloudClient* in_client);
+	void SetupSocket(const FString& url, BrainCloudClient* mClient);
 
 	void Connect();
 
@@ -42,7 +46,11 @@ public:
 
 	void SendData(const TArray<uint8>& data);
 
+	void ResetCallbacks();
+
 	bool IsConnected();
+
+	bool IsLoggingEnabled();
 
 	FWinWebSocketReceiveData OnReceiveData;
 
@@ -54,7 +62,7 @@ public:
 
 	FWinWebSocketConnectError OnConnectError;
 
-	IWinWebSocketBaseCallbacks* mCallbacks;
+	IWinWebSocketBaseCallbacks* mCallbacks = nullptr;
 
 private:
 	FString BytesToString(const void* Data, SIZE_T Size);
@@ -64,8 +72,6 @@ private:
 	TArray<FString> mSendQueue;
 	TArray<TArray<uint8>> mSendQueueData;
 	bool mIsLoggingEnabled;
-
-	bool isLoggingEnabled();
 	
 };
 

--- a/Source/BCClientPlugin/Public/BrainCloudClient.h
+++ b/Source/BCClientPlugin/Public/BrainCloudClient.h
@@ -560,7 +560,7 @@ class BCCLIENTPLUGIN_API BrainCloudClient
 	void overrideLanguageCode(const FString &languageCode) { _language = languageCode; }
 
   protected:
-	void initializeComms(const char *serverUrl, const char *appId, const TMap<FString, FString> &secretMap);
+
 	BrainCloudComms *_brainCloudComms = nullptr;
 	BrainCloudRTTComms *_brainCloudRTTComms = nullptr;
 	BrainCloudRelayComms *_brainCloudRelayComms = nullptr;


### PR DESCRIPTION
Fixed issue where the WebSocket object is not cleaned up properly on destroy
Fixed issue with the OnRecv function passing in a reference to the json message, it is now passing a copy of that json message instead of a reference to account for a crash issue happening where the reference points to a null value on rare occasions.
Removed a function that is never used