### PR TITLE
Nick/minor fixes

### DIFF
--- a/Source/BCClientPlugin/Private/BlueprintProxies/BCWrapperProxy.cpp
+++ b/Source/BCClientPlugin/Private/BlueprintProxies/BCWrapperProxy.cpp
@@ -30,7 +30,7 @@ void UBCWrapperProxy::SetDefaultBrainCloudInstance(UBrainCloudWrapper *brainClou
 
 void UBCWrapperProxy::ClearDefaultBrainCloudInstance()
 {
-	if (ensureAlways(DefaultBrainCloudInstance != nullptr))
+	if (DefaultBrainCloudInstance.IsValid())
 		DefaultBrainCloudInstance->RemoveFromRoot();
 	DefaultBrainCloudInstance = nullptr;
 }

--- a/Source/BCClientPlugin/Private/BrainCloudAuthentication.cpp
+++ b/Source/BCClientPlugin/Private/BrainCloudAuthentication.cpp
@@ -305,7 +305,7 @@ void BrainCloudAuthentication::authenticate(
 
 	if(OperationParam::isOptionalParamValid(in_extraJson))
 	{
-		message->SetStringField(OperationParam::AuthenticateServiceAuthenticateExtraJson.getValue(), in_extraJson);
+		message->SetObjectField(OperationParam::AuthenticateServiceAuthenticateExtraJson.getValue(), JsonUtil::jsonStringToValue(in_extraJson));
 	}
 	
 	FString countryCode = brainCloudClientRef->getCountryCode();

--- a/Source/BCClientPlugin/Private/BrainCloudIdentity.cpp
+++ b/Source/BCClientPlugin/Private/BrainCloudIdentity.cpp
@@ -67,7 +67,7 @@ void BrainCloudIdentity::attachAdvancedIdentity(EBCAuthType authenticationType, 
 
 	if(OperationParam::isOptionalParamValid(extraJson))
 	{
-		message->SetStringField(OperationParam::AuthenticateServiceAuthenticateExtraJson.getValue(), extraJson);
+		message->SetObjectField(OperationParam::AuthenticateServiceAuthenticateExtraJson.getValue(), JsonUtil::jsonStringToValue(extraJson));
 	}
 
 	if(OperationParam::isOptionalParamValid(ids.authenticationSubType))
@@ -88,7 +88,7 @@ void BrainCloudIdentity::mergeAdvancedIdentity(EBCAuthType authenticationType, c
 
 	if(OperationParam::isOptionalParamValid(extraJson))
 	{
-		message->SetStringField(OperationParam::AuthenticateServiceAuthenticateExtraJson.getValue(), extraJson);
+		message->SetObjectField(OperationParam::AuthenticateServiceAuthenticateExtraJson.getValue(), JsonUtil::jsonStringToValue(extraJson));
 	}
 
 	if(OperationParam::isOptionalParamValid(ids.authenticationSubType))
@@ -109,7 +109,7 @@ void BrainCloudIdentity::detachAdvancedIdentity(EBCAuthType authenticationType, 
 
 	if(OperationParam::isOptionalParamValid(extraJson))
 	{
-		message->SetStringField(OperationParam::AuthenticateServiceAuthenticateExtraJson.getValue(), extraJson);
+		message->SetObjectField(OperationParam::AuthenticateServiceAuthenticateExtraJson.getValue(), JsonUtil::jsonStringToValue(extraJson));
 	}
 
 	ServerCall *sc = new ServerCall(ServiceName::Identity, ServiceOperation::Detach, message, callback);

--- a/Source/BCClientPlugin/Private/BrainCloudRTTComms.cpp
+++ b/Source/BCClientPlugin/Private/BrainCloudRTTComms.cpp
@@ -294,11 +294,11 @@ void BrainCloudRTTComms::processRegisteredListeners(const FString &in_service, c
 		// error callback!
 		if (m_appCallback != nullptr)
 		{
-			m_appCallback->serverError(ServiceName::RTTRegistration, ServiceOperation::Connect, 400, -1, "RTT Connection has been closed. Re-Enable RTT to re-establish connection : " + in_jsonMessage);
+			m_appCallback->serverError(ServiceName::RTTRegistration, ServiceOperation::Connect, 400, -1, in_jsonMessage);
 		}
 		else if (m_appCallbackBP != nullptr)
 		{
-			m_appCallbackBP->serverError(ServiceName::RTTRegistration, ServiceOperation::Connect, 400, -1, "RTT Connection has been closed. Re-Enable RTT to re-establish connection : " + in_jsonMessage);
+			m_appCallbackBP->serverError(ServiceName::RTTRegistration, ServiceOperation::Connect, 400, -1, in_jsonMessage);
 		}
 		m_disconnectedWithReason = true;
 		return;

--- a/Source/BCClientPlugin/Private/WinWebSocketBase.cpp
+++ b/Source/BCClientPlugin/Private/WinWebSocketBase.cpp
@@ -11,7 +11,6 @@ void UWinWebSocketBase::BeginDestroy()
 		WebSocket->OnMessage().Clear();
 		WebSocket->OnRawMessage().Clear();
 		WebSocket->OnConnectionError().Clear();
-		WebSocket->Close();
 		WebSocket.Reset();
 	}
 

--- a/Source/BCClientPlugin/Private/WinWebSocketBase.h
+++ b/Source/BCClientPlugin/Private/WinWebSocketBase.h
@@ -19,6 +19,7 @@ DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FWinWebSocketConnectError, const FSt
 class IWinWebSocketBaseCallbacks
 {
 public:
+	virtual ~IWinWebSocketBaseCallbacks() {}
 	virtual void OnConnectError(const FString& error) = 0;
 	virtual void OnClosed() = 0;
 	virtual void OnConnectComplete() = 0;


### PR DESCRIPTION
- Switched to using SetObjectField for setting json params for API calls instead of SetStringField
- Removed prefixed string when calling the error callback for RTT and passing just the json error 
- Removed EnsureAlways instruction in ClearDefaultBrainCloudInstance function to just an if statement to prevent an ensure being hit consistently when this function is called the first time
- Added destructor for abstract class WinWebSocketBase
- Removed duplicate call for `Close` for the WebSocket object

Windows Unit Tests: https://vmjenkins.bitheads.com/view/Dev_Unreal/job/bitHeads_BrainCloud_Client_UnitTest_UnrealEngine_Win64_develop_internal/1172/

Linux Unit Tests: https://vmjenkins.bitheads.com/view/Dev_Unreal/job/bitHeads_BrainCloud_Client_UnitTest_UnrealEngine_Linux_develop_internal/77

Mac Unit Tests: https://vmjenkins.bitheads.com/view/Dev_Unreal/job/bitHeads_BrainCloud_Client_UnitTest_UnrealEngine_MacOS_develop_internal/1125/