### PR TITLE
Fixed BCLOUD-9319

### DIFF
--- a/Source/BCClientPlugin/Private/BlueprintProxies/BCLobbyProxy.cpp
+++ b/Source/BCClientPlugin/Private/BlueprintProxies/BCLobbyProxy.cpp
@@ -13,12 +13,10 @@ UBCLobbyProxy::UBCLobbyProxy(const FObjectInitializer &ObjectInitializer)
 {
 }
 
-UBCLobbyProxy *UBCLobbyProxy::FindLobby(UBrainCloudWrapper *brainCloudWrapper, const FString &in_roomType, int32 in_rating, int32 in_maxSteps,
-										const FString &in_algoJson, const FString &in_filterJson, int32 in_timeoutSecs,
-										bool in_isReady, const FString &in_extraJson, const FString &in_teamCode, const TArray<FString> &in_otherUserCxIds)
+UBCLobbyProxy* UBCLobbyProxy::FindLobby(UBrainCloudWrapper* brainCloudWrapper, const FString& in_roomType, int32 in_rating, int32 in_maxSteps, const FString& in_algoJson, const FString& in_filterJson, bool in_isReady, const FString& in_extraJson, const FString& in_teamCode, const TArray<FString>& in_otherUserCxIds)
 {
-	UBCLobbyProxy *Proxy = NewObject<UBCLobbyProxy>();
-	UBCWrapperProxy::GetBrainCloudInstance(brainCloudWrapper)->getLobbyService()->findLobby(in_roomType, in_rating, in_maxSteps, in_algoJson, in_filterJson, in_timeoutSecs, in_isReady, in_extraJson, in_teamCode, in_otherUserCxIds, Proxy);
+	UBCLobbyProxy* Proxy = NewObject<UBCLobbyProxy>();
+	UBCWrapperProxy::GetBrainCloudInstance(brainCloudWrapper)->getLobbyService()->findLobby(in_roomType, in_rating, in_maxSteps, in_algoJson, in_filterJson, in_isReady, in_extraJson, in_teamCode, in_otherUserCxIds, Proxy);
 	return Proxy;
 }
 

--- a/Source/BCClientPlugin/Private/BlueprintProxies/BCLobbyProxy.h
+++ b/Source/BCClientPlugin/Private/BlueprintProxies/BCLobbyProxy.h
@@ -33,7 +33,7 @@ class UBCLobbyProxy : public UBCBlueprintCallProxyBase
     */
     UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = "true"), Category = "BrainCloud|Lobby")
     static UBCLobbyProxy *FindLobby(UBrainCloudWrapper *brainCloudWrapper, const FString &in_roomType, int32 in_rating, int32 in_maxSteps,
-                                    const FString &in_algoJson, const FString &in_filterJson, int32 in_timeoutSecs,
+                                    const FString &in_algoJson, const FString &in_filterJson,
                                     bool in_isReady, const FString &in_extraJson, const FString &in_teamCode, const TArray<FString> &in_otherUserCxIds);
 
     /**

--- a/Source/BCClientPlugin/Private/BrainCloudLobby.cpp
+++ b/Source/BCClientPlugin/Private/BrainCloudLobby.cpp
@@ -23,6 +23,7 @@ BrainCloudLobby::BrainCloudLobby(BrainCloudClient *client)
      _http = &FHttpModule::Get();
  }
 
+
 void BrainCloudLobby::findLobby(const FString &in_roomType, int32 in_rating, int32 in_maxSteps,
                                 const FString &in_algoJson, const FString &in_filterJson, int32 in_timeoutSecs,
                                 bool in_isReady, const FString &in_extraJson, const FString &in_teamCode, const TArray<FString> &in_otherUserCxIds,
@@ -41,6 +42,23 @@ void BrainCloudLobby::findLobby(const FString &in_roomType, int32 in_rating, int
     message->SetArrayField(OperationParam::LobbyOtherUserCxIds.getValue(), JsonUtil::arrayToJsonArray(in_otherUserCxIds));
 
     ServerCall *sc = new ServerCall(ServiceName::Lobby, ServiceOperation::FindLobby, message, in_callback);
+    _client->sendRequest(sc);
+}
+
+void BrainCloudLobby::findLobby(const FString& in_roomType, int32 in_rating, int32 in_maxSteps, const FString& in_algoJson, const FString& in_filterJson, bool in_isReady, const FString& in_extraJson, const FString& in_teamCode, const TArray<FString>& in_otherUserCxIds, IServerCallback* in_callback)
+{
+    TSharedRef<FJsonObject> message = MakeShareable(new FJsonObject());
+    message->SetStringField(OperationParam::LobbyRoomType.getValue(), in_roomType);
+    message->SetNumberField(OperationParam::LobbyRating.getValue(), in_rating);
+    message->SetNumberField(OperationParam::LobbyMaxSteps.getValue(), in_maxSteps);
+    message->SetObjectField(OperationParam::LobbyAlgorithm.getValue(), JsonUtil::jsonStringToValue(in_algoJson));
+    message->SetObjectField(OperationParam::LobbyFilterJson.getValue(), JsonUtil::jsonStringToValue(in_filterJson));
+    message->SetBoolField(OperationParam::LobbyIsReady.getValue(), in_isReady);
+    message->SetObjectField(OperationParam::LobbyExtraJson.getValue(), JsonUtil::jsonStringToValue(in_extraJson));
+    message->SetStringField(OperationParam::LobbyTeamCode.getValue(), in_teamCode);
+    message->SetArrayField(OperationParam::LobbyOtherUserCxIds.getValue(), JsonUtil::arrayToJsonArray(in_otherUserCxIds));
+
+    ServerCall* sc = new ServerCall(ServiceName::Lobby, ServiceOperation::FindLobby, message, in_callback);
     _client->sendRequest(sc);
 }
 

--- a/Source/BCClientPlugin/Public/BrainCloudLobby.h
+++ b/Source/BCClientPlugin/Public/BrainCloudLobby.h
@@ -36,10 +36,34 @@ class BCCLIENTPLUGIN_API BrainCloudLobby : public IServerCallback
     * @param in_otherUserCxIds array of other user Connection Ids to bring when the lobby is found
 	* @param in_callback Method to be invoked when the server response is received.
     */
+    [[deprecated("Use the findLobby function that does not contain the in_timeoutSecs parameter")]]
     void findLobby(const FString &in_roomType, int32 in_rating, int32 in_maxSteps,
                    const FString &in_algoJson, const FString &in_filterJson, int32 in_timeoutSecs,
                    bool in_isReady, const FString &in_extraJson, const FString &in_teamCode, const TArray<FString> &in_otherUserCxIds,
                    IServerCallback *in_callback);
+
+    /**
+    * Finds a lobby matching the specified parameters
+    *
+    * Service Name - lobby
+    * Service Operation - FIND_LOBBY
+    *
+    * @param in_roomType type of room
+    * @param in_rating rating of the room
+    * @param in_maxSteps max iterations to search for a lobby
+    * @param in_algoJson json string of the search algorithm to use
+    * @param in_filterJson json string of the filter to be passed on
+    * @param in_timeoutSecs numberOfseconds before timing out
+    * @param in_isReady when lobby is found, place this user as "Ready"
+    * @param in_extraJson json string for extra customization
+    * @param in_teamCode team code
+    * @param in_otherUserCxIds array of other user Connection Ids to bring when the lobby is found
+    * @param in_callback Method to be invoked when the server response is received.
+    */
+    void findLobby(const FString& in_roomType, int32 in_rating, int32 in_maxSteps,
+        const FString& in_algoJson, const FString& in_filterJson,
+        bool in_isReady, const FString& in_extraJson, const FString& in_teamCode, const TArray<FString>& in_otherUserCxIds,
+        IServerCallback* in_callback);
 
   /**
     * Finds a lobby matching the specified parameters WITH PING DATA.  GetRegionsForLobbies and PingRegions must be successfully responded to prior to calling.


### PR DESCRIPTION
https://bitheads.atlassian.net/browse/BCLOUD-9319

- Added new findLobby function that does not have the timeoutsecs param
- Deprecated old findLobby function
- Updated the Blueprint proxy to use the new function instead, which means removing the timeoutsecs param from the blueprint node as well. This creates a warning in any project that uses the Find Lobby node, the dev would only have to refresh the node to remove the warning.

<img width="313" height="468" alt="image" src="https://github.com/user-attachments/assets/2c17c39e-be6d-4de0-80ff-5267dcb0b5b0" /> Once the node is refreshed the warning goes away as well as the In Timeout Secs param

This is the only way because it is not possible to overload blueprint functions, if 2 functions have the same name and are blueprint callable functions it won't compile.

Windows Lobby test: https://vmjenkins.bitheads.com/view/Dev_Unreal/job/bitHeads_BrainCloud_Client_UnitTest_UnrealEngine_Win64_develop_internal/1244/

MacOS Lobby test: https://vmjenkins.bitheads.com/view/Dev_Unreal/job/bitHeads_BrainCloud_Client_UnitTest_UnrealEngine_MacOS_develop_internal/1176/